### PR TITLE
Made ConsoleFormatter compatible with unsized consoles.

### DIFF
--- a/src/Yaclops/Formatting/ConsoleFormatter.cs
+++ b/src/Yaclops/Formatting/ConsoleFormatter.cs
@@ -10,15 +10,7 @@ namespace Yaclops.Formatting
 
         public void Format(Document doc)
         {
-            int width = int.MaxValue;
-            try
-            {
-                width = Console.WindowWidth;
-            }
-            catch
-            {
-                // Probably in Windows Application mode or some other process where stdout is unsized 
-            }
+            int width = Console.IsOutputRedirected ? int.MaxValue : Console.WindowWidth;
 
             foreach (var para in doc.Paragraphs)
             {

--- a/src/Yaclops/Formatting/ConsoleFormatter.cs
+++ b/src/Yaclops/Formatting/ConsoleFormatter.cs
@@ -10,7 +10,15 @@ namespace Yaclops.Formatting
 
         public void Format(Document doc)
         {
-            int width = Console.WindowWidth;    // TODO - WindowWidth or BufferWidth?
+            int width = int.MaxValue;
+            try
+            {
+                width = Console.WindowWidth;
+            }
+            catch
+            {
+                // Probably in Windows Application mode or some other process where stdout is unsized 
+            }
 
             foreach (var para in doc.Paragraphs)
             {


### PR DESCRIPTION
Fixes Windows API error getting console width when running as non-Console application (stdout redirected to IDE).

WindowWidth seems correct since the buffer size can be set to a larger number and induce scrolling.